### PR TITLE
Workaround para atual server-side pagination parcial

### DIFF
--- a/src/pages/Acervo.vue
+++ b/src/pages/Acervo.vue
@@ -112,12 +112,12 @@ export default {
     async getFileMidias () {
       this.loading = true
       try {
-        // const { data } = await this.$axios.get(
-        //   `/acervo/find?tipos=arquivo&pag_tamanho=${this.queryParameters.pag_tamanho}&pag_atual=${this.queryParameters.pag_atual}`
-        // )
         const { data } = await this.$axios.get(
-          '/acervo/find?tipos=arquivo'
+          '/acervo/find?tipos=arquivo&pag_tamanho=1000&pag_atual=1'
         )
+        // const { data } = await this.$axios.get(
+        //   '/acervo/find?tipos=arquivo'
+        // )
         this.midiaItems = data
         this.loading = false
       } catch (error) {
@@ -133,12 +133,12 @@ export default {
     async getImageMidias () {
       this.loading = true
       try {
-        // const { data } = await this.$axios.get(
-        //   `/acervo/find?tipos=imagem&pag_tamanho=${this.queryParameters.pag_tamanho}&pag_atual=${this.queryParameters.pag_atual}`
-        // )
         const { data } = await this.$axios.get(
-          '/acervo/find?tipos=imagem'
+          '/acervo/find?tipos=imagem&pag_tamanho=1000&pag_atual=1'
         )
+        // const { data } = await this.$axios.get(
+        //   '/acervo/find?tipos=imagem'
+        // )
         this.midiaItems = data
         this.loading = false
       } catch (error) {
@@ -154,12 +154,12 @@ export default {
     async getVideoMidias () {
       this.loading = true
       try {
-        // const { data } = await this.$axios.get(
-        //   `/acervo/find?tipos=video&pag_tamanho=${this.queryParameters.pag_tamanho}&pag_atual=${this.queryParameters.pag_atual}`
-        // )
         const { data } = await this.$axios.get(
-          '/acervo/find?tipos=video'
+          '/acervo/find?tipos=video&pag_tamanho=1000&pag_atual=1'
         )
+        // const { data } = await this.$axios.get(
+        //   '/acervo/find?tipos=video'
+        // )
         this.midiaItems = data
         this.loading = false
       } catch (error) {
@@ -175,12 +175,12 @@ export default {
     async getAudioMidias () {
       this.loading = true
       try {
-        // const { data } = await this.$axios.get(
-        //   `/acervo/find?tipos=audio&pag_tamanho=${this.queryParameters.pag_tamanho}&pag_atual=${this.queryParameters.pag_atual}`
-        // )
         const { data } = await this.$axios.get(
-          '/acervo/find?tipos=audio'
+          '/acervo/find?tipos=audio&pag_tamanho=1000&pag_atual=1'
         )
+        // const { data } = await this.$axios.get(
+        //   '/acervo/find?tipos=audio'
+        // )
         this.midiaItems = data
         this.loading = false
       } catch (error) {


### PR DESCRIPTION
Presentemente, a API que serve o Janereka Ryru conta com suporte à paginação dos arquivos de mídia. Entretanto, a serialização das respostas não inclui informações que qual a página atual e quantas páginas existem, considerando o total de items e número de items por página.

Além disso, quando omitidos os parâmetros de `pag_tamanho `e de `pag_atual `dos enpoints com paginação (como, por exemplo, `/acervo/find`), um default de 12 items por página, e página 1, é automaticamente inferido.

Isso leva à uma incompatibilidade com o layout proposto pra a tabela do acervo. Nessa tabela, o componente de paginação informa o total de arquivos e o index dos arquivos na página atual. Além disso, seus botões de navegação são desabilitados ao se encontrar na primeira ou na última página do total.

Ao não se incluir:

- Número da página atual
- Número total de páginas
- Número total de items

Na reposta do endpoint, alcançar o layout de paginação conforme descrito acima se torna inviável. O default de 12 items por página quando não se inclui query parameters de paginação no request, também omite todos os arquivos com index superior aos 12 primeiros encontrados no acervo.

Conquanto perdure a não inclusão de dados de paginação na resposta, essa limitação é contornada requisitando-se um número alto de arquivos, de modo a se calcular esses parâmetros manualmente no frontend. Obviamente essa deve ser uma solução temporária, haja vista que irá gerar alto overhead no servidor ao passo que muitos arquivos sejam submetidos ao acervo, e também demanda recursos desnecessários no frontend.
